### PR TITLE
Check for GitHub.com provider type

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -24,6 +24,7 @@ import {
     GitHubLazyProjectLoader,
     GoalSigningScope,
     PushImpact,
+    pushTest,
 } from "@atomist/sdm";
 import { configure } from "@atomist/sdm-core";
 import { aspectSupport } from "@atomist/sdm-pack-aspect";
@@ -33,6 +34,7 @@ import {
     RebaseFailure,
     RebaseStrategy,
 } from "@atomist/sdm-pack-fingerprint";
+import * as _ from "lodash";
 import { createAspects } from "./lib/aspect/aspects";
 import { RegistrationsBackedAspectsFactory } from "./lib/aspect/aspectsFactory";
 import {
@@ -66,6 +68,7 @@ import {
     createFingerprintJob,
     createFingerprintJobCommand,
 } from "./lib/job/createFingerprintJob";
+import { ProviderType } from "./lib/typings/types";
 import { gitHubCommandSupport } from "./lib/util/commentCommand";
 import { MessageRoutingAutomationEventListener } from "./lib/util/MessageRoutingAutomationEventListener";
 import { RemoveIntentsMetadataProcessor } from "./lib/util/removeIntents";
@@ -149,6 +152,9 @@ export const configuration: Configuration = configure(async sdm => {
 
             return {
                 analyze: {
+                    test: pushTest("Is GitHub.com", async p => {
+                        return _.get(p.push, "repo.org.provider.providerType", ProviderType.github_com) === ProviderType.github_com;
+                    }),
                     goals: [
                         [pushImpact],
                     ],


### PR DESCRIPTION
Add a push test to schedule fingerprinting only on GitHub.com repositories.